### PR TITLE
Invoke ect with multithreaded deflate enabled

### DIFF
--- a/lib/pdfsizeopt/main.py
+++ b/lib/pdfsizeopt/main.py
@@ -9437,8 +9437,8 @@ IMAGE_OPTIMIZER_CMD_MAP = {
     'optipng':  'optipng %(sourcefnq)s -o4 -fix -force %(optipng_gray_flags)s-out %(targetfnq)s',
     'optipng4': 'optipng %(sourcefnq)s -o4 -fix -force %(optipng_gray_flags)s-out %(targetfnq)s',
     'optipng7': 'optipng %(sourcefnq)s -o7 -fix -force %(optipng_gray_flags)s-out %(targetfnq)s',  # Slowest.
-    'ect': 'ECT -9 -strip %(targetfnq)s',
-    'ECT': 'ECT -9 -strip %(targetfnq)s',
+    'ect': 'ECT -9 -strip --mt-deflate %(targetfnq)s',
+    'ECT': 'ECT -9 -strip --mt-deflate %(targetfnq)s',
     'advpng':  'advpng -z3 -f %(targetfnq)s',
     'advpng3': 'advpng -z3 -f %(targetfnq)s',
     'advpng4': 'advpng -z4 -f %(targetfnq)s',  # Slowest, this uses Zopfli.


### PR DESCRIPTION
Add `--mt-deflate` flag to the `ect` invocations to to enable multithreaded deflate compression.